### PR TITLE
Improve CI for `servant-rate-limit`

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -8,6 +8,9 @@ on:
       - "*"
     paths:
       - ".github/workflows/**"
+      - "servant-rate-limit/src/**"
+      - "servant-rate-limit/test/**"
+      - "servant-rate-limit/package.yaml"
       - "wai-rate-limit/src/**"
       - "wai-rate-limit/package.yaml"
       - "wai-rate-limit-redis/src/**"

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -29,6 +29,12 @@ jobs:
           - "stack-lts-16.1"
           - "stack-lts-18"
           - "stack-lts-19"
+        servant-server-flag: # on by default
+          - ""
+          - "--flag servant-rate-limit:-server"
+        servant-client-flag: # on by default
+          - ""
+          - "--flag servant-rate-limit:-client"
 
     runs-on: ubuntu-latest
 
@@ -43,28 +49,44 @@ jobs:
           stack-setup-ghc: true
           stack-version: "latest"
 
+      - name: Write flags to file (for hashing)
+        run: |
+          echo ${{ matrix.servant-server-flag }} >> .cabal-flags
+          echo ${{ matrix.servant-client-flag }} >> .cabal-flags
+          cat .cabal-flags
+
       - name: Cache .stack
         id: cache-stack
         uses: actions/cache@v3
         with:
           path: ${{ steps.install-haskell.outputs.stack-root }}
-          key: ${{ runner.os }}-${{ matrix.resolver }}-${{ hashFiles(format('{0}.yaml', matrix.resolver)) }}-${{ hashFiles('**/*.cabal') }}
+          key: ${{ runner.os }}-${{ matrix.resolver }}-${{ hashFiles(format('{0}.yaml', matrix.resolver)) }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('.cabal-flags') }}
           restore-keys: |
+            ${{ runner.os }}-${{ matrix.resolver }}-${{ hashFiles(format('{0}.yaml', matrix.resolver)) }}-${{ hashFiles('**/*.cabal') }}-
             ${{ runner.os }}-${{ matrix.resolver }}-${{ hashFiles(format('{0}.yaml', matrix.resolver)) }}-
             ${{ runner.os }}-${{ matrix.resolver }}-
 
       - name: Install dependencies
         run: |
-          stack --stack-yaml=${{ matrix.resolver }}.yaml --no-terminal build --only-dependencies --fast
+          stack --stack-yaml=${{ matrix.resolver }}.yaml --no-terminal build \
+            ${{ matrix.servant-server-flag }} \
+            ${{ matrix.servant-client-flag }} \
+            --only-dependencies --fast
 
       - name: Build
         id: build
         run: |
-          stack --stack-yaml=${{ matrix.resolver }}.yaml --no-terminal build --fast --test --no-run-tests
+          stack --stack-yaml=${{ matrix.resolver }}.yaml --no-terminal build \
+            ${{ matrix.servant-server-flag }} \
+            ${{ matrix.servant-client-flag }} \
+            --fast --test --no-run-tests
 
       - name: Test
         id: test
         run: |
           docker-compose up -d
-          stack --stack-yaml=${{ matrix.resolver }}.yaml --no-terminal test --fast
+          stack --stack-yaml=${{ matrix.resolver }}.yaml --no-terminal test \
+            ${{ matrix.servant-server-flag }} \
+            ${{ matrix.servant-client-flag }} \
+            --fast
           docker-compose down

--- a/servant-rate-limit/package.yaml
+++ b/servant-rate-limit/package.yaml
@@ -81,3 +81,9 @@ tests:
       - wai-extra
       - wai-rate-limit-redis
       - warp
+    when:
+      condition: flag(server) && flag(client)
+      then:
+        buildable: true
+      else:
+        buildable: false

--- a/servant-rate-limit/servant-rate-limit.cabal
+++ b/servant-rate-limit/servant-rate-limit.cabal
@@ -119,4 +119,11 @@ test-suite servant-rate-limit-tests
   if flag(client)
     build-depends:
         servant-client
+  if flag(openapi)
+    build-depends:
+        servant-openapi3
+  if flag(server) && flag(client)
+    buildable: True
+  else
+    buildable: False
   default-language: Haskell2010

--- a/servant-rate-limit/src/Servant/RateLimit/Client.hs
+++ b/servant-rate-limit/src/Servant/RateLimit/Client.hs
@@ -12,7 +12,9 @@ module Servant.RateLimit.Client where
 
 --------------------------------------------------------------------------------
 
-import Servant
+import Data.Proxy
+
+import Servant.API
 import Servant.Client
 import Servant.RateLimit.Types
 

--- a/servant-rate-limit/src/Servant/RateLimit/Server.hs
+++ b/servant-rate-limit/src/Servant/RateLimit/Server.hs
@@ -41,7 +41,7 @@ import Servant.Server.Internal.DelayedIO
 
 -- | A class of types which are type-level descriptions of rate-limiting
 -- strategies.
-class HasRateLimitStrategy (ctx :: [*]) strategy where
+class HasRateLimitStrategy (ctx :: [Type]) strategy where
     -- | `strategyValue` @context backend getKey@ is a function which, given a
     -- @backend@ and a function @getKey@ used to compute the key using which
     -- the client should be identified, returns a rate-limiting `Strategy`.
@@ -72,7 +72,7 @@ instance
 
 -- | A class of types which are type-level descriptions of rate-limiting
 -- policies.
-class HasRateLimitPolicy (ctx :: [*]) policy where
+class HasRateLimitPolicy (ctx :: [Type]) policy where
     type RateLimitPolicyKey ctx policy :: Type
 
     -- | `policyGetIdentifier` @context request@ computes the key that should

--- a/servant-rate-limit/src/Servant/RateLimit/Types.hs
+++ b/servant-rate-limit/src/Servant/RateLimit/Types.hs
@@ -5,11 +5,6 @@
 -- file in the root directory of this source tree.                            --
 --------------------------------------------------------------------------------
 
-{-# LANGUAGE AllowAmbiguousTypes #-}
-{-# LANGUAGE KindSignatures #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE UndecidableInstances #-}
-
 module Servant.RateLimit.Types (
     -- * Servant combinator
     RateLimit,
@@ -17,11 +12,9 @@ module Servant.RateLimit.Types (
     -- * Rate-limiting strategies
     FixedWindow,
     SlidingWindow,
-    HasRateLimitStrategy(..),
 
     -- * Rate-limiting policies
     IPAddressPolicy,
-    HasRateLimitPolicy(..),
 
     -- * Re-exports
     module Data.Time.TypeLevel
@@ -31,17 +24,7 @@ module Servant.RateLimit.Types (
 
 import GHC.TypeLits
 
-import Data.ByteString.Char8 as C8
-import Data.Kind
-import Data.Proxy
-import qualified Data.Time.Units as Units
 import Data.Time.TypeLevel
-
-import Network.Wai
-import Network.Wai.RateLimit.Backend
-import Network.Wai.RateLimit.Strategy
-
-import Servant (Context)
 
 --------------------------------------------------------------------------------
 
@@ -51,37 +34,6 @@ data FixedWindow (dur :: TimePeriod) (capacity :: Nat)
 -- | A type-level description for the parameters of the `slidingWindow`
 -- strategy.
 data SlidingWindow (dur :: TimePeriod) (capacity :: Nat)
-
--- | A class of types which are type-level descriptions of rate-limiting
--- strategies.
-class HasRateLimitStrategy (ctx :: [*]) strategy where
-    -- | `strategyValue` @context backend getKey@ is a function which, given a
-    -- @backend@ and a function @getKey@ used to compute the key using which
-    -- the client should be identified, returns a rate-limiting `Strategy`.
-    strategyValue ::
-        Context ctx -> Backend key -> (Request -> IO key) -> Strategy
-
-instance
-    (KnownDuration dur, KnownNat capacity, Units.TimeUnit (DurationUnit dur))
-    => HasRateLimitStrategy ctx (FixedWindow dur capacity)
-    where
-
-    strategyValue _ backend getKey = fixedWindow
-        backend
-        (Units.convertUnit $ durationVal @dur)
-        (fromInteger $ natVal (Proxy :: Proxy capacity))
-        getKey
-
-instance
-    (KnownDuration dur, KnownNat capacity, Units.TimeUnit (DurationUnit dur))
-    => HasRateLimitStrategy ctx (SlidingWindow dur capacity)
-    where
-
-    strategyValue _ backend getKey = slidingWindow
-        backend
-        (Units.convertUnit $ durationVal @dur)
-        (fromInteger $ natVal (Proxy :: Proxy capacity))
-        getKey
 
 --------------------------------------------------------------------------------
 
@@ -93,27 +45,6 @@ instance
 -- but can be set to other values to have different rate limits for different
 -- sets of endpoints.
 data IPAddressPolicy (prefix :: Symbol)
-
--- | A class of types which are type-level descriptions of rate-limiting
--- policies.
-class HasRateLimitPolicy (ctx :: [*]) policy where
-    type RateLimitPolicyKey ctx policy :: Type
-
-    -- | `policyGetIdentifier` @context request@ computes the key that should
-    -- be used by the backend to identify the client to which the rate
-    -- limiting policy should be applied to. This could be as simple
-    -- as retrieving the IP address of the client from @request@
-    -- (as is the case with `IPAddressPolicy`) or retrieving data from
-    -- the @request@ vault. The computation runs in `IO` to allow policies
-    -- to perform arbitrary effects.
-    policyGetIdentifier :: Context ctx -> Request -> IO (RateLimitPolicyKey ctx policy)
-
-instance KnownSymbol prefix => HasRateLimitPolicy ctx (IPAddressPolicy prefix) where
-    type RateLimitPolicyKey ctx (IPAddressPolicy prefix) = ByteString
-
-    policyGetIdentifier _ =
-        pure . (C8.pack (symbolVal (Proxy :: Proxy prefix)) <>) .
-        C8.pack . show . remoteHost
 
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
The `haskell.yml` workflow wasn't updated when `servant-rate-limit` was added to the repository. This PR updates the workflow for the new package and also fixes some bugs that showed up as a result of those changes:
- The workflow's build matrix now includes the package flags for `servant-rate-limit` to build all permutations of those flags.
- Building `servant-rate-limit-tests` is now conditional on the `server` and `client` flags. The tests require both the server and client code to function.
- The `HasRateLimitStrategy` and `HasRateLimitPolicy` classes have been moved to the `Servant.RateLimit.Server` module. They are only required for the server implementation and are now dependent on the `Context` type, which is only available in `servant-server`.
- Some imports have been reshuffled for `Servant.RateLimit.Client` so it does no longer depend on `servant-server`.
- `Type` is used instead of `*` in `Servant.RateLimit.Server`