### PR TITLE
Add basic `servant-openapi3` support

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -35,6 +35,9 @@ jobs:
         servant-client-flag: # on by default
           - ""
           - "--flag servant-rate-limit:-client"
+        servant-openapi-flag: # off by default
+          - ""
+          - "--flag servant-rate-limit:openapi"
 
     runs-on: ubuntu-latest
 

--- a/servant-rate-limit/package.yaml
+++ b/servant-rate-limit/package.yaml
@@ -45,6 +45,10 @@ flags:
     description: Enable servant-client support.
     manual: true
     default: true
+  openapi:
+    description: Enable servant-openapi3 support.
+    manual: true
+    default: false
 
 when:
   - condition: flag(server)
@@ -53,6 +57,10 @@ when:
   - condition: flag(client)
     dependencies:
       - servant-client
+  - condition: flag(openapi)
+    dependencies:
+      - openapi3
+      - servant-openapi3
 
 library:
   source-dirs: src
@@ -65,6 +73,9 @@ library:
     - condition: flag(client)
       exposed-modules:
         - Servant.RateLimit.Client
+    - condition: flag(openapi)
+      exposed-modules:
+        - Servant.RateLimit.OpenApi
 
 tests:
   servant-rate-limit-tests:

--- a/servant-rate-limit/servant-rate-limit.cabal
+++ b/servant-rate-limit/servant-rate-limit.cabal
@@ -30,6 +30,11 @@ flag client
   manual: True
   default: True
 
+flag openapi
+  description: Enable servant-openapi3 support.
+  manual: True
+  default: False
+
 flag server
   description: Enable servant-server support.
   manual: True
@@ -69,12 +74,19 @@ library
   if flag(client)
     build-depends:
         servant-client
+  if flag(openapi)
+    build-depends:
+        openapi3
+      , servant-openapi3
   if flag(server)
     exposed-modules:
         Servant.RateLimit.Server
   if flag(client)
     exposed-modules:
         Servant.RateLimit.Client
+  if flag(openapi)
+    exposed-modules:
+        Servant.RateLimit.OpenApi
   default-language: Haskell2010
 
 test-suite servant-rate-limit-tests
@@ -121,7 +133,8 @@ test-suite servant-rate-limit-tests
         servant-client
   if flag(openapi)
     build-depends:
-        servant-openapi3
+        openapi3
+      , servant-openapi3
   if flag(server) && flag(client)
     buildable: True
   else

--- a/servant-rate-limit/servant-rate-limit.cabal
+++ b/servant-rate-limit/servant-rate-limit.cabal
@@ -119,6 +119,9 @@ test-suite servant-rate-limit-tests
   if flag(client)
     build-depends:
         servant-client
+  if flag(openapi)
+    build-depends:
+        servant-openapi3
   if flag(server) && flag(client)
     buildable: True
   else

--- a/servant-rate-limit/src/Servant/RateLimit/OpenApi.hs
+++ b/servant-rate-limit/src/Servant/RateLimit/OpenApi.hs
@@ -1,0 +1,38 @@
+--------------------------------------------------------------------------------
+-- Rate Limiting Middleware for Servant                                       --
+--------------------------------------------------------------------------------
+-- This source code is licensed under the MIT license found in the LICENSE    --
+-- file in the root directory of this source tree.                            --
+--------------------------------------------------------------------------------
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | Defines an instance of `HasOpenApi` for the `RateLimit` combinator.
+module Servant.RateLimit.OpenApi () where
+
+--------------------------------------------------------------------------------
+
+import Data.Function
+import Data.OpenApi
+import Data.Proxy
+
+import Servant.API
+import Servant.OpenApi
+import Servant.RateLimit
+
+--------------------------------------------------------------------------------
+
+add429response :: OpenApi -> OpenApi
+add429response =
+    setResponseWith (const mkResponse) 429 (pure $ mkResponse mempty)
+    where
+        mkResponse res = res{
+            _responseDescription = "Rate limited"
+        }
+
+instance HasOpenApi api => HasOpenApi (RateLimit strategy policy :> api) where
+    toOpenApi _ = toOpenApi (Proxy :: Proxy api)
+        & add429response
+
+--------------------------------------------------------------------------------


### PR DESCRIPTION
Adds support for `servant-openapi3`, which is gated behind a `servant-rate-limit:openapi` flag that is off by default.